### PR TITLE
Enable random-route

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,4 @@ applications:
   memory: 128M
   instances: 1
   path: .
+  random-route: true


### PR DESCRIPTION
It’s wise for an example app which basically does nothing to have `--random-route` set to prevent collisions. 